### PR TITLE
Fix typo and iOS web view class name

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,18 +201,18 @@
 
           <h4>iOS</h4>
           <p>
-            Although Safari has a UIWebView component which lets developers
+            Although Safari has a WKWebView component which lets developers
             embed websites into an iOS app, this sadly does not work when
             embedding pages leveraging the WebRTC technology Whereby is built
             on. This leaves two options for native iOS apps:
           </p>
           <ul>
             <li>Redirect to mobile Safari</li>
-            <li>Use SFSafariViewControlleri</li>
+            <li>Use SFSafariViewController</li>
           </ul>
           <p>If you need your own UI at the same time as the
           Whereby-meeting, it would be possible to use
-          <em>SFSafariViewControlleri</em> to embed a website where you show
+          <em>SFSafariViewController</em> to embed a website where you show
           your UI and again use an iframe to embed Whereby.
 
           <h4>Customizing the room</h4>


### PR DESCRIPTION
- UIWebView is deprecated, iOS developers are using WKWebView these days
- Typo in SFSafariViewController