### PR TITLE
docs: add ?people=on/off 

### DIFF
--- a/embed/index.html
+++ b/embed/index.html
@@ -80,6 +80,12 @@ output {
     <td><code>&lt;whereby-embed chat=off /&gt;</code> <code>&lt;whereby-embed minimal chat /&gt;</code>
   </tr>
   <tr>
+    <th><code>people</code>
+    <td><code>"off"</code>
+    <td>Disable the participant list
+    <td><code>&lt;whereby-embed people=off /&gt;</code>
+  </tr>
+  <tr>
     <th><code>leaveButton</code>
     <td>nothing (on) or <code>"off"</code>
     <td>Enable/disable the leave button

--- a/embed/tester/tester.js
+++ b/embed/tester/tester.js
@@ -9,6 +9,7 @@ const boolAttrs = [
   "help",
   "leaveButton",
   "minimal",
+  "people",
   "precallReview",
   "recording",
   "screenshare",

--- a/embed/whereby-embed.js
+++ b/embed/whereby-embed.js
@@ -4,6 +4,7 @@ const boolAttrs = [
   "audio",
   "background",
   "chat",
+  "people",
   "embed",
   "emptyRoomInvitation",
   "help",

--- a/index.html
+++ b/index.html
@@ -248,7 +248,7 @@
             each user.
           </p>
 
-          <h4 id=params-stacking>Stacking Parameters</h4>
+          <h4 id=params-stacking>Stacking parameters</h4>
           <p>
             It is easy to use more than one parameter at a time for each
             meeting room or participant. In fact, you can use as many you
@@ -404,7 +404,7 @@
           </p>
           <h4>People</h4>
           <p>The participant list sidebar is enabled in the default embed scenario but the button to toggle it is only visible to the meeting host. The participant list may be of use as it provides access to tools to bulk manage participants. One reason you may want to disable the participant list completely is if you enable the chat function and don't want the participant list to show up as a second tab in the sidebar.</p>
-          <h4>Leave Button</h4>
+          <h4>Leave button</h4>
           <p>
             Similar to the chat button, the leave button is automatically
             removed whenever you use the embed function. The reasoning behind
@@ -434,7 +434,7 @@
             browser they’re using supports screenshare, something no mobile
             browsers supports yet.
           </p>
-          <h4>Display Name</h4>
+          <h4>Display name</h4>
           <p>
             The display name parameter allows you to choose the name displayed
             for any participant entering a call.
@@ -469,7 +469,7 @@
             because the recordings are stored locally on your machine.
           </p>
 
-          <h4>Host Privileges</h4>
+          <h4>Host privileges</h4>
           <p>
             With the Whereby meetings API, you can assign someone as the host is
             by providing them access to the room with a host room URL link. This
@@ -496,7 +496,7 @@
             Importantly, whenever a host refreshes their page, they will still
             have host room privileges as the URL remains the same.
           </p>
-          <h4>The Lifecycle of your Room</h4>
+          <h4>The lifecycle of your room</h4>
           <p>
             When a Whereby room link is created, it is immediately available.
           </p>

--- a/index.html
+++ b/index.html
@@ -271,6 +271,7 @@
             <tr><th><code>?video=off</code>                             <td>Enter meeting with video off</tr>
             <tr><th><code>?background=off</code>                        <td>Render without background to let embedding app render its own</tr>
             <tr><th><code>?chat=&lt;on|off&gt;</code>                   <td>Enable/disable chat</tr>
+            <tr><th><code>?people=off</code>                            <td>Disable participant list</tr>
             <tr><th><code>?leaveButton=&lt;on|off&gt;</code>            <td>Enable/disable leave button</tr>
             <tr><th><code>?recording=&lt;on|off&gt;</code>              <td>Enable/disable recording (only for host)</tr>
             <tr><th><code>?screenshare=&lt;on|off&gt;</code>            <td>Enable/disable screenshare</tr>
@@ -401,6 +402,8 @@
             simply add the chat on parameter to your URL, stacked with the embed
             parameter.
           </p>
+          <h4>People</h4>
+          <p>The participant list sidebar is enabled in the default embed scenario but the button to toggle it is only visible to the meeting host. The participant list may be of use as it provides access to tools to bulk manage participants. One reason you may want to disable the participant list completely is if you enable the chat function and don't want the participant list to show up as a second tab in the sidebar.</p>
           <h4>Leave Button</h4>
           <p>
             Similar to the chat button, the leave button is automatically


### PR DESCRIPTION
Documents the new `?people=on/off` attribute which defaults to on. The `People` button itself is now hidden from the video controls for guests by default, this flag removes the sidebar and the button from the host's video controls.

Also tried to tidy up some of the title casing which looked inconsistent.